### PR TITLE
Add optional exit status reporting

### DIFF
--- a/entr.c
+++ b/entr.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[]) {
 	argv_index = set_options(argv);
 
 	/* normally a user will exit this utility by do_execting Ctrl-C */
-	act.sa_flags = 0;
+	act.sa_flags = SA_RESETHAND;
 	act.sa_handler = handle_exit;
 	if (sigemptyset(&act.sa_mask) & (sigaction(SIGINT, &act, NULL) != 0))
 		err(1, "Failed to set SIGINT handler");
@@ -229,7 +229,6 @@ terminate_utility() {
 
 void
 handle_exit(int sig) {
-	/*signal(sig, SIG_DFL);*/
 	if (fifo.fd) {
 		close(fifo.fd);
 		unlink(fifo.fn);
@@ -237,7 +236,7 @@ handle_exit(int sig) {
         /* Disable status report, no stdio is allowed in sig handlers */
         exit_opt = 0;
 	terminate_utility();
-	exit(0);
+	raise(sig);
 }
 
 /*


### PR DESCRIPTION
It can be very useful to know the exit status of the utility,
particularly when running tap-style unit tests, where failure is
indicated by a non-zero exit status.

Works for me on Linux, untested on OS X. If you are interested in merging, I can confirm the kqueue implementation for OS X, and update the README.
